### PR TITLE
Change session storage to use ETS instead of cookies

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,6 @@ use Mix.Config
 config :verk_web, VerkWeb.Endpoint,
   url: [host: "localhost"],
   root: Path.dirname(__DIR__),
-  secret_key_base: "NnVD42IPn6ciZm+YWuH9d+QDWwy70D0e9f+HUUwKr038+jqoKTq6qU5r4CJZM4L6",
   render_errors: [accepts: ~w(html json)],
   pubsub: [name: VerkWeb.PubSub,
            adapter: Phoenix.PubSub.PG2]

--- a/lib/verk_web.ex
+++ b/lib/verk_web.ex
@@ -1,26 +1,17 @@
 defmodule VerkWeb do
   use Application
 
-  # See http://elixir-lang.org/docs/stable/elixir/Application.html
-  # for more information on OTP Applications
+  @doc false
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    children = [
-      # Start the endpoint when the application starts
-      supervisor(VerkWeb.Endpoint, []),
-      # Here you could define other workers and supervisors as children
-      # worker(VerkWeb.Worker, [arg1, arg2, arg3]),
-    ]
-
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
-    # for other strategies and supported options
+    children = [supervisor(VerkWeb.Endpoint, [])]
+    :ets.new(:verk_web_session, [:named_table, :public, read_concurrency: true])
     opts = [strategy: :one_for_one, name: VerkWeb.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
+  @doc false
   def config_change(changed, _new, removed) do
     VerkWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/lib/verk_web/endpoint.ex
+++ b/lib/verk_web/endpoint.ex
@@ -29,9 +29,9 @@ defmodule VerkWeb.Endpoint do
   plug Plug.Head
 
   plug Plug.Session,
-    store: :cookie,
-    key: "_verk_web_key",
-    signing_salt: "RqGexWNP"
+    store: :ets,
+    key: "verk_web_sid",
+    table: :verk_web_session
 
   plug VerkWeb.Router
 end

--- a/mix.lock
+++ b/mix.lock
@@ -22,6 +22,7 @@
   "ranch": {:hex, :ranch, "1.2.0"},
   "redix": {:hex, :redix, "0.3.4"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "1.0.1"},
+  "timex": {:hex, :timex, "1.0.2"},
   "tzdata": {:hex, :tzdata, "0.5.6"},
-  "verk": {:hex, :verk, "0.9.6"}}
+  "verk": {:hex, :verk, "0.9.6"},
+  "watcher": {:hex, :watcher, "1.0.0"}}


### PR DESCRIPTION
There's no need for a cookie store as (for now) verk_web is a standalone interface of a running Verk instance.