### PR TITLE
Conditional enqueued at display

### DIFF
--- a/web/templates/retries/index.html.eex
+++ b/web/templates/retries/index.html.eex
@@ -12,7 +12,6 @@
           <th></th>
           <th>Id</th>
           <th>Retry count</th>
-          <th>Enqueued at</th>
           <th>Class/Worker</th>
           <th>Arguments</th>
           <th></th>
@@ -24,7 +23,6 @@
           <td><input name="jobs_to_remove[]" type="checkbox" value="<%= job.original_json %>" id="job_<%= job.jid %>" /></td>
           <td><%= job.jid %></td>
           <td><%= job.retry_count %></td>
-          <td><%= job.enqueued_at %>
           <td><%= job.class %></td>
           <td><%= job.args %></td>
           <td>

--- a/web/templates/shared/job_modal.html.eex
+++ b/web/templates/shared/job_modal.html.eex
@@ -10,7 +10,7 @@
           <tbody>
           <tr>
             <th>Enqueued at</th>
-            <td><%= @job.enqueued_at |> Timex.Date.from(:secs) |> Timex.DateFormat.format!("{ISO}") %></td>
+            <td><%= enqueued_at(@job.enqueued_at) %></td>
           </tr>
           <tr>
             <th>Finished at</th>

--- a/web/views/retries_view.ex
+++ b/web/views/retries_view.ex
@@ -5,7 +5,6 @@ defmodule VerkWeb.RetriesView do
     Enum.map failed_jobs, fn failed_job ->
       %{
         jid: failed_job.jid,
-        enqueued_at: failed_job.enqueued_at |> Timex.Date.from(:secs) |> Timex.DateFormat.format!("{ISO}"),
         retry_count: failed_job.retry_count,
         class: failed_job.class,
         args: failed_job.args |> inspect,

--- a/web/views/shared_view.ex
+++ b/web/views/shared_view.ex
@@ -1,3 +1,8 @@
 defmodule VerkWeb.SharedView do
   use VerkWeb.Web, :view
+
+  def enqueued_at(nil), do: "N/A"
+  def enqueued_at(timestamp) do
+    timestamp |> Timex.Date.from(:secs) |> Timex.DateFormat.format!("{ISO}")
+  end
 end


### PR DESCRIPTION
* Remove `enqueued_at` from the retries page
* Make it optional for the job modal