### PR TITLE
Change page template to display Redis counts

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -25,5 +25,5 @@
   "redix": {:hex, :redix, "0.4.0", "c8cfad755252e5441c4119437ba3a8989518af7aa90dbd6f4ff7207b72e4a967", [:mix], [{:connection, "~> 1.0.0", [hex: :connection, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "verk": {:hex, :verk, "0.13.1", "7c9940a49abf903040fed8424bf4f2bd67363b8e85647ca470bcd2621967fa9d", [:mix], [{:poison, "~> 2.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5.1", [hex: :poolboy, optional: false]}, {:redix, "~> 0.4", [hex: :redix, optional: false]}, {:watcher, "~> 1.0", [hex: :watcher, optional: false]}]},
+  "verk": {:hex, :verk, "0.13.2", "7028f7dba362c6119ac8d556b7726247e447e85a92e2ba7fb9e63a4b528535e5", [:mix], [{:poison, "~> 2.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5.1", [hex: :poolboy, optional: false]}, {:redix, "~> 0.4", [hex: :redix, optional: false]}, {:watcher, "~> 1.0", [hex: :watcher, optional: false]}]},
   "watcher": {:hex, :watcher, "1.0.0", "0d9a43d0f1f3997b75775fc873dfb29437b8e3c5fb6bdcb8feaa5eedc7ee9cf6", [:mix], []}}

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -10,6 +10,8 @@
         <th># Enqueued</th>
         <th># Processed</th>
         <th># Failed</th>
+        <th># Lifetime Processed</th>
+        <th># Lifetime Failed</th>
       </tr>
     </thead>
     <tbody>
@@ -20,6 +22,8 @@
           <td><%= link queue.enqueued_counter |> to_string, to: queues_path(@conn, :show, queue.queue) %></td>
           <td><%= queue.finished_counter %></td>
           <td><%= queue.failed_counter %></td>
+          <td><%= queue.total_processed %></td>
+          <td><%= queue.total_failed %></td>
         </tr>
       <% end %>
     </tbody>

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -4,6 +4,7 @@ defmodule VerkWeb.PageView do
   def stats(queues_stats) do
     Enum.map queues_stats, fn queue_stats ->
       Map.put(queue_stats, :enqueued_counter, Verk.Queue.count!(queue_stats.queue))
+      |> Map.merge(Verk.Stats.queue_total(queue_stats.queue))
     end
   end
 end


### PR DESCRIPTION
Addresses issue #26

Relies on https://github.com/edgurgel/verk/pull/86

Previously "Processed" and "Failed" counts per queue were pulled from `:ets`. This meant that VerkWeb would only show the number of jobs processed/failed since that Verk instance had started. Because we are already storing the stats in Redis, this PR chooses to pull stats from the database instead.

This is just a first pass, would love to get some feedback and hoping to add some tests as well.