### PR TITLE
Link Verk in dev env, fixes #30

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,6 +6,9 @@ use Mix.Config
 # The watchers configuration can be used to run external
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
+config :verk_web,
+  link_verk_supervisor: true
+
 config :verk_web, VerkWeb.Endpoint,
   http: [port: 4000],
   debug_errors: true,

--- a/lib/verk_web.ex
+++ b/lib/verk_web.ex
@@ -6,6 +6,9 @@ defmodule VerkWeb do
     import Supervisor.Spec, warn: false
 
     children = [supervisor(VerkWeb.Endpoint, [])]
+    if Application.get_env(:verk_web, :link_verk_supervisor, false) do
+      children = [supervisor(Verk.Supervisor, []) | children]
+    end
     :ets.new(:verk_web_session, [:named_table, :public, read_concurrency: true])
     opts = [strategy: :one_for_one, name: VerkWeb.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
A possible solution for #30. Allows for running VerkWeb in development without having to do any manual configuration.