### PR TITLE
Truncate long job args in retries/dead tabs

### DIFF
--- a/web/templates/dead/index.html.eex
+++ b/web/templates/dead/index.html.eex
@@ -24,7 +24,13 @@
           <td><%= job.jid %></td>
           <td><%= job.retry_count %></td>
           <td><%= job.class %></td>
-          <td><%= job.args %></td>
+          <td>
+            <%= if String.length(job.args) > 128 do
+                  String.slice(job.args, 0, 128) <> "..."
+                else
+                  job.args
+                end %>
+          </td>
           <td>
             <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#job-<%= job.jid %>-modal">
               Details

--- a/web/templates/retries/index.html.eex
+++ b/web/templates/retries/index.html.eex
@@ -24,7 +24,13 @@
           <td><%= job.jid %></td>
           <td><%= job.retry_count %></td>
           <td><%= job.class %></td>
-          <td><%= job.args %></td>
+          <td>
+            <%= if String.length(job.args) > 128 do
+                  String.slice(job.args, 0, 128) <> "..."
+                else
+                  job.args
+                end %>
+          </td>
           <td>
             <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#job-<%= job.jid %>-modal">
               Details


### PR DESCRIPTION
We have lots of jobs with huge args (thousands of characters), which makes it hard to look at the retries tab. The 128 character limit is arbitrary, happy to increase it if would make more sense.

How it looked before:
<img width="1211" alt="screen shot 2016-11-02 at 9 55 43 am" src="https://cloud.githubusercontent.com/assets/6401746/19931654/b5f520ea-a0e3-11e6-940d-f2b2c6fe7433.png">

How it looks now:
<img width="1144" alt="screen shot 2016-11-02 at 9 56 01 am" src="https://cloud.githubusercontent.com/assets/6401746/19931677/c775386e-a0e3-11e6-85cf-ce016270c5d3.png">