### PR TITLE
Upgrade Timex to 3.1.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule VerkWeb.Mixfile do
      {:ex_doc, "~> 0.13", only: :dev},
      {:coverex, "~> 1.4", only: :test},
      {:meck, "~> 0.8", only: :test},
-     {:timex, "~> 3.0.0"}]
+     {:timex, "~> 3.1.0"}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -24,7 +24,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "redix": {:hex, :redix, "0.4.0", "c8cfad755252e5441c4119437ba3a8989518af7aa90dbd6f4ff7207b72e4a967", [:mix], [{:connection, "~> 1.0.0", [hex: :connection, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
-  "timex": {:hex, :timex, "3.0.8", "71d5ebafcdc557c6c866cdc196c5054f587e7cd1118ad8937e2293d51fc85608", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "timex": {:hex, :timex, "3.1.5", "413d6d8d6f0162a5d47080cb8ca520d790184ac43e097c95191c7563bf25b428", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "verk": {:hex, :verk, "0.13.3", "0e00e4e7b0f09a3ca20bc7907c153e17dc711856c3d7a1634cac4c863d195c83", [:mix], [{:poison, "~> 2.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5.1", [hex: :poolboy, optional: false]}, {:redix, "~> 0.4", [hex: :redix, optional: false]}, {:watcher, "~> 1.0", [hex: :watcher, optional: false]}]},
   "watcher": {:hex, :watcher, "1.0.0", "0d9a43d0f1f3997b75775fc873dfb29437b8e3c5fb6bdcb8feaa5eedc7ee9cf6", [:mix], []}}


### PR DESCRIPTION
gettext 0.12.x support wasn't added to Timex until 3.1.1, see:
https://github.com/bitwalker/timex/pull/229
https://github.com/bitwalker/timex/issues/228

Somehow this issue flew under the radar until after the upgrade to Timex 3.0.8 was already merged, see:
https://github.com/edgurgel/verk_web/pull/34#issuecomment-259251636