### PR TITLE
Update README to include WebSocket configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ config :verk_web, VerkWeb.Endpoint,
 ```
 Now VerkWeb would run on port 4000,
 
+## Allowing WebSocket connections
 
+VerkWeb's default host configuration is `localhost`. While this works in development, in order to allow WebSocket connections (which are required for the auto-updating overview graph) you need to update the host used in [`Phoenix.Endpoint.url`](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html) to the host from which you are attempting to connect from. If this is not set correctly you can expect the following error message in your browser console logs:
+
+```
+WebSocket connection to 'ws://<YOUR_HOST>/socket/websocket?vsn=1.0.0' failed: Error during WebSocket handshake: Unexpected response code: 403
+```
+
+To resolve this update your configuration to the actual host for the environment by adding the following configuration:
+
+```elixir
+# in config.exs:
+config :verk_web, VerkWeb.Endpoint,
+  url: [host: "<YOUR_HOST>"]
+```
 
 ## What it looks like
 


### PR DESCRIPTION
This gave me some trouble for a while as I didn't realize why VerkWeb wasn't able to open the WebSocket connection. Luckily having this not working doesn't affect anything except the (awesome) live-reloading overview graph.

For more context see:
https://github.com/phoenixframework/phoenix/issues/1096

Also, `master` branch is working well for us in production so far!

![screen shot 2016-12-15 at 6 53 15 pm](https://cloud.githubusercontent.com/assets/6401746/21247048/b09406c8-c2fa-11e6-984d-659cd445d18a.png)
