### PR TITLE
Add Schedule Tab

### DIFF
--- a/web/controllers/scheduled_controller.ex
+++ b/web/controllers/scheduled_controller.ex
@@ -1,0 +1,17 @@
+defmodule VerkWeb.ScheduledController do
+  use VerkWeb.Web, :controller
+
+  @schedule_key "schedule"
+
+  def index(conn, params) do
+    paginator = VerkWeb.RangePaginator.new(Verk.SortedSet.count!(@schedule_key, Verk.Redis), params["page"], params["per_page"])
+
+    render conn, "index.html",
+      queue: @schedule_key,
+      scheduled_jobs: Verk.SortedSet.range_with_score!(@schedule_key, paginator.from, paginator.to, Verk.Redis),
+      has_next: paginator.has_next,
+      has_prev: paginator.has_prev,
+      page: paginator.page,
+      per_page: paginator.per_page
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -23,6 +23,7 @@ defmodule VerkWeb.Router do
     get "/queues/:queue/jobs/:job_id", JobController, :show
     get "/retries", RetriesController, :index
     delete "/retries", RetriesController, :destroy
+    get "/scheduled", ScheduledController, :index
     get "/dead", DeadController, :index
     delete "/dead", DeadController, :destroy
   end

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -28,6 +28,7 @@
             <%= menu_item(@conn, page_path(@conn, :index), "Dashboard") %>
             <%= menu_item(@conn, queues_path(@conn, :index), "Queues") %>
             <%= menu_item(@conn, retries_path(@conn, :index), "Retries") %>
+            <%= menu_item(@conn, scheduled_path(@conn, :index), "Scheduled") %>
             <%= menu_item(@conn, dead_path(@conn, :index), "Dead") %>
           </ul>
         </div>

--- a/web/templates/scheduled/index.html.eex
+++ b/web/templates/scheduled/index.html.eex
@@ -1,0 +1,48 @@
+<h2>Scheduled jobs</h2>
+
+<%= if @scheduled_jobs |> Enum.empty? do %>
+  <p>No scheduled jobs.</p>
+<% else %>
+  <div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Queue</th>
+          <th>Id</th>
+          <th>Class/Worker</th>
+          <th>Arguments</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      <%= for job <- scheduled_jobs(@scheduled_jobs) do %>
+        <tr>
+          <td><%= perform_at(job.perform_at) %></td>
+          <td><%= job.queue %></td>
+          <td><%= job.jid %></td>
+          <td><%= job.class %></td>
+          <td><%= job.args %></td>
+          <td>
+            <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#job-<%= job.jid %>-modal">
+              Details
+            </button>
+
+            <%= render VerkWeb.SharedView, "job_modal.html", job: job.job, perform_at: job.perform_at, conn: @conn %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+    <div>
+      <%= if @has_prev do %>
+        <span><%= link "Previous", to: scheduled_path(@conn, :index, page: @page - 1, per_page: @per_page), class: "btn btn-default" %></span>
+      <% end %>
+
+      <%= if @has_next do %>
+        <span><%= link "Next", to: scheduled_path(@conn, :index, page: @page + 1, per_page: @per_page), class: "btn btn-default" %></span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/web/templates/shared/job_modal.html.eex
+++ b/web/templates/shared/job_modal.html.eex
@@ -8,6 +8,12 @@
       <div class="modal-body">
         <table class="table">
           <tbody>
+          <%= if @perform_at do %>
+            <tr>
+              <th>Perform at</th>
+              <td><%= @perform_at %></td>
+            </tr>
+          <% end %>
           <tr>
             <th>Enqueued at</th>
             <td><%= enqueued_at(@job.enqueued_at) %></td>
@@ -44,8 +50,10 @@
         </table>
       </div>
       <div class="modal-footer">
-        <%= link to: job_path(@conn, :show, @job.queue, @job.jid) do %>
-          <button type="button" class="btn btn-info">Inspect</button>
+        <%= unless @perform_at do %>
+          <%= link to: job_path(@conn, :show, @job.queue, @job.jid) do %>
+            <button type="button" class="btn btn-info">Inspect</button>
+          <%= end %>
         <%= end %>
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
       </div>

--- a/web/views/scheduled_view.ex
+++ b/web/views/scheduled_view.ex
@@ -1,0 +1,20 @@
+defmodule VerkWeb.ScheduledView do
+  use VerkWeb.Web, :view
+
+  def scheduled_jobs(jobs) do
+    Enum.map jobs, fn {job, perform_at} ->
+      %{
+        perform_at: Timex.from_unix(perform_at),
+        queue: job.queue,
+        jid: job.jid,
+        class: job.class,
+        args: job.args |> inspect,
+        job: job
+      }
+    end
+  end
+
+  def perform_at(datetime) do
+    Timex.format!(datetime, "{relative}", :relative)
+  end
+end


### PR DESCRIPTION
Add a tab for schedule that lists off all scheduled jobs, when they are
scheduled to run, and on which queue.

It reuses the same job modal and adds a "Perform at" item if it's a scheduled
job and removes the "inspect" button since that won't really provide more
context than is already visible for a scheduled job.

![screen shot 2016-12-30 at 11 40 05](https://cloud.githubusercontent.com/assets/3799709/21571545/4ff60c44-ce85-11e6-8135-6b20cf29006e.png)
![screen shot 2016-12-30 at 11 40 09](https://cloud.githubusercontent.com/assets/3799709/21571546/5217d5c0-ce85-11e6-9eb3-fbc6c13368ea.png)

refs https://github.com/edgurgel/verk_web/issues/12
