### PR TITLE
Check assigns presence before using it

### DIFF
--- a/web/templates/shared/job_modal.html.eex
+++ b/web/templates/shared/job_modal.html.eex
@@ -8,10 +8,10 @@
       <div class="modal-body">
         <table class="table">
           <tbody>
-          <%= if @perform_at do %>
+          <%= if assigns[:perform_at] do %>
             <tr>
               <th>Perform at</th>
-              <td><%= @perform_at %></td>
+              <td><%= assigns[:perform_at] %></td>
             </tr>
           <% end %>
           <tr>
@@ -50,7 +50,7 @@
         </table>
       </div>
       <div class="modal-footer">
-        <%= unless @perform_at do %>
+        <%= unless assigns[:perform_at] do %>
           <%= link to: job_path(@conn, :show, @job.queue, @job.jid) do %>
             <button type="button" class="btn btn-info">Inspect</button>
           <%= end %>


### PR DESCRIPTION
Since we call this shared view in a few places, but only pass in the
`perform_at` assign in one, this was erroring out on other screens where we
attempted to use it. By checking that it's available first, we resolve that
issue.