### PR TITLE
Delete scheduled jobs from dashboard

### DIFF
--- a/test/controllers/scheduled_controller_test.exs
+++ b/test/controllers/scheduled_controller_test.exs
@@ -1,0 +1,26 @@
+defmodule VerkWeb.ScheduledControllerTest do
+  use VerkWeb.ConnCase
+  alias Verk.{SortedSet, Redis}
+  import :meck, except: [delete: 3]
+
+  setup do
+    new SortedSet
+    on_exit fn -> unload() end
+    :ok
+  end
+
+  test "DELETE / jobs delete specific jobs", %{conn: conn} do
+    fake_job_json = "{\"jid\": \"123\"}"
+    expect(SortedSet, :delete_job!, ["schedule", fake_job_json, Redis], :ok)
+    conn = delete conn, "/scheduled", jobs_to_remove: [fake_job_json]
+    assert validate SortedSet
+    assert redirected_to(conn) == "/scheduled"
+  end
+
+  test "DELETE / passing no jobs deletes all jobs", %{conn: conn} do
+    expect(SortedSet, :clear!, ["schedule", Redis], :ok)
+    conn = delete conn, "/scheduled"
+    assert validate SortedSet
+    assert redirected_to(conn) == "/scheduled"
+  end
+end

--- a/web/controllers/scheduled_controller.ex
+++ b/web/controllers/scheduled_controller.ex
@@ -1,17 +1,31 @@
 defmodule VerkWeb.ScheduledController do
   use VerkWeb.Web, :controller
+  alias Verk.{SortedSet, Redis}
 
   @schedule_key "schedule"
 
   def index(conn, params) do
-    paginator = VerkWeb.RangePaginator.new(Verk.SortedSet.count!(@schedule_key, Verk.Redis), params["page"], params["per_page"])
+    paginator = VerkWeb.RangePaginator.new(SortedSet.count!(@schedule_key, Redis), params["page"], params["per_page"])
 
     render conn, "index.html",
       queue: @schedule_key,
-      scheduled_jobs: Verk.SortedSet.range_with_score!(@schedule_key, paginator.from, paginator.to, Verk.Redis),
+      scheduled_jobs: SortedSet.range_with_score!(@schedule_key, paginator.from, paginator.to, Redis),
       has_next: paginator.has_next,
       has_prev: paginator.has_prev,
       page: paginator.page,
       per_page: paginator.per_page
+  end
+
+  def destroy(conn, %{ "jobs_to_remove" => jobs_to_remove }) do
+    jobs_to_remove = jobs_to_remove || []
+
+    for job <- jobs_to_remove, do: SortedSet.delete_job!(@schedule_key, job, Redis)
+
+    redirect conn, to: scheduled_path(conn, :index)
+  end
+  def destroy(conn, _params) do
+    Verk.SortedSet.clear!(@schedule_key, Verk.Redis)
+
+    redirect conn, to: scheduled_path(conn, :index)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -24,6 +24,7 @@ defmodule VerkWeb.Router do
     get "/retries", RetriesController, :index
     delete "/retries", RetriesController, :destroy
     get "/scheduled", ScheduledController, :index
+    delete "/scheduled", ScheduledController, :destroy
     get "/dead", DeadController, :index
     delete "/dead", DeadController, :destroy
   end

--- a/web/templates/scheduled/index.html.eex
+++ b/web/templates/scheduled/index.html.eex
@@ -4,45 +4,59 @@
   <p>No scheduled jobs.</p>
 <% else %>
   <div>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Queue</th>
-          <th>Id</th>
-          <th>Class/Worker</th>
-          <th>Arguments</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-      <%= for job <- scheduled_jobs(@scheduled_jobs) do %>
-        <tr>
-          <td><%= perform_at(job.perform_at) %></td>
-          <td><%= job.queue %></td>
-          <td><%= job.jid %></td>
-          <td><%= job.class %></td>
-          <td><%= job.args %></td>
-          <td>
-            <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#job-<%= job.jid %>-modal">
-              Details
-            </button>
+    <%= form_for @conn, scheduled_path(@conn, :destroy), [as: :delete_job, method: "DELETE"], fn _ -> %>
+      <input name="jobs_to_remove[]" type="hidden" value="" />
+      <table class="table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>When</th>
+            <th>Queue</th>
+            <th>Id</th>
+            <th>Class/Worker</th>
+            <th>Arguments</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+        <%= for job <- scheduled_jobs(@scheduled_jobs) do %>
+          <tr>
+            <td><input name="jobs_to_remove[]" type="checkbox" value="<%= job.job.original_json %>" id="job_<%= job.jid %>" /></td>
+            <td><%= perform_at(job.perform_at) %></td>
+            <td><%= job.queue %></td>
+            <td><%= job.jid %></td>
+            <td><%= job.class %></td>
+            <td><%= job.args %></td>
+            <td>
+              <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#job-<%= job.jid %>-modal">
+                Details
+              </button>
 
-            <%= render VerkWeb.SharedView, "job_modal.html", job: job.job, perform_at: job.perform_at, conn: @conn %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
+              <%= render VerkWeb.SharedView, "job_modal.html", job: job.job, perform_at: job.perform_at, conn: @conn %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
 
-    <div>
-      <%= if @has_prev do %>
-        <span><%= link "Previous", to: scheduled_path(@conn, :index, page: @page - 1, per_page: @per_page), class: "btn btn-default" %></span>
-      <% end %>
+      <div class="row">
+        <div class="col-md-4">
+          <%= submit "Delete selected", class: "btn btn-danger btn-sm" %>
+        </div>
 
-      <%= if @has_next do %>
-        <span><%= link "Next", to: scheduled_path(@conn, :index, page: @page + 1, per_page: @per_page), class: "btn btn-default" %></span>
-      <% end %>
-    </div>
+        <div class="col-md-8 text-right">
+          <%= if @has_prev do %>
+            <span><%= link "Previous", to: scheduled_path(@conn, :index, page: @page - 1, per_page: @per_page), class: "btn btn-default" %></span>
+          <% end %>
+
+          <%= if @has_next do %>
+            <span><%= link "Next", to: scheduled_path(@conn, :index, page: @page + 1, per_page: @per_page), class: "btn btn-default" %></span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
+  <p>
+    <%= button "Delete all", to: scheduled_path(@conn, :destroy), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-sm" %>
+  </p>
 <% end %>


### PR DESCRIPTION
Add checkboxes to the schedule tab that allows you to delete one or many
scheduled jobs. This works the same way as it does on the retries tab. The code
is mostly copied over from there.

<img width="1193" alt="screen shot 2017-02-05 at 9 04 57 pm" src="https://cloud.githubusercontent.com/assets/3799709/22635241/ca8127fe-ebe6-11e6-9100-40e2edb39a18.png">
