### PR TITLE
Retry now button

### DIFF
--- a/test/controllers/retries_controller_test.exs
+++ b/test/controllers/retries_controller_test.exs
@@ -9,10 +9,17 @@ defmodule VerkWeb.RetriesControllerTest do
     :ok
   end
 
-  test "DELETE / jobs delete expecific jobs", %{conn: conn} do
+  test "POST / action delete jobs delete specific jobs", %{conn: conn} do
     fake_job_json = "{\"jid\": \"123\"}"
     expect(RetrySet, :delete_job!, [fake_job_json], :ok)
-    delete conn, "/retries", jobs_to_remove: [fake_job_json]
+    post conn, "/retries", [jobs_to_modify: [fake_job_json], action: "delete"]
+    assert validate RetrySet
+  end
+
+  test "POST / action retry jobs retries specific jobs", %{conn: conn} do
+    fake_job_json = "{\"jid\": \"123\"}"
+    expect(RetrySet, :requeue_job!, [fake_job_json], :ok)
+    post conn, "/retries", [jobs_to_modify: [fake_job_json], action: "requeue"]
     assert validate RetrySet
   end
 

--- a/web/controllers/retries_controller.ex
+++ b/web/controllers/retries_controller.ex
@@ -15,15 +15,24 @@ defmodule VerkWeb.RetriesController do
       per_page: paginator.per_page
   end
 
-  def destroy(conn, %{ "jobs_to_remove" => jobs_to_remove }) do
+  def destroy(conn, _params) do
+    RetrySet.clear!
+
+    redirect conn, to: retries_path(conn, :index)
+  end
+
+  def modify(conn, %{ "action" => "delete", "jobs_to_modify" => jobs_to_remove }) do
     jobs_to_remove = jobs_to_remove || []
 
     for job <- jobs_to_remove, do: RetrySet.delete_job!(job)
 
     redirect conn, to: retries_path(conn, :index)
   end
-  def destroy(conn, _params) do
-    RetrySet.clear!
+
+  def modify(conn, %{ "action" => "requeue", "jobs_to_modify" => jobs_to_requeue }) do
+    jobs_to_requeue = jobs_to_requeue || []
+
+    for job <- jobs_to_requeue, do: RetrySet.requeue_job!(job)
 
     redirect conn, to: retries_path(conn, :index)
   end

--- a/web/controllers/retries_controller.ex
+++ b/web/controllers/retries_controller.ex
@@ -32,7 +32,7 @@ defmodule VerkWeb.RetriesController do
   def modify(conn, %{ "action" => "requeue", "jobs_to_modify" => jobs_to_requeue }) do
     jobs_to_requeue = jobs_to_requeue || []
 
-    for job <- jobs_to_requeue, do: RetrySet.requeue_job!(job)
+    for job <- jobs_to_requeue, job != "", do: RetrySet.requeue_job!(job)
 
     redirect conn, to: retries_path(conn, :index)
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -22,6 +22,7 @@ defmodule VerkWeb.Router do
     get "/queues/:queue/busy", QueuesController, :busy
     get "/queues/:queue/jobs/:job_id", JobController, :show
     get "/retries", RetriesController, :index
+    post "/retries", RetriesController, :modify
     delete "/retries", RetriesController, :destroy
     get "/scheduled", ScheduledController, :index
     delete "/scheduled", ScheduledController, :destroy

--- a/web/templates/retries/index.html.eex
+++ b/web/templates/retries/index.html.eex
@@ -6,8 +6,8 @@
   <p>No jobs waiting to be retried at the moment.</p>
 <% else %>
   <div>
-    <%= form_for @conn, retries_path(@conn, :destroy), [as: :delete_job, method: "DELETE"], fn _ -> %>
-    <input name="jobs_to_remove[]" type="hidden" value="" />
+    <%= form_for @conn, retries_path(@conn, :modify), [as: :modify, method: "POST"], fn _ -> %>
+    <input name="jobs_to_modify[]" type="hidden" value="" />
     <table id="retries-table" class="table table-blocks">
       <thead>
         <tr>
@@ -23,7 +23,7 @@
       <tbody>
       <%= for job <- jobs(@failed_jobs) do %>
         <tr>
-          <td><input name="jobs_to_remove[]" type="checkbox" value="<%= job.original_json %>" id="job_<%= job.jid %>" /></td>
+          <td><input name="jobs_to_modify[]" type="checkbox" value="<%= job.original_json %>" id="job_<%= job.jid %>" /></td>
           <td><code><%= job.jid %></code></td>
           <td><%= job.retry_count %></td>
           <td><%= job.score %></td>
@@ -48,8 +48,12 @@
     </table>
 
     <div class="row">
-      <div class="col-md-4">
-        <%= submit "Delete selected", class: "btn btn-danger btn-sm" %>
+      <div class="col-md-2">
+        <%= submit "Delete selected", class: "btn btn-danger btn-sm", name: "action", value: "delete" %>
+      </div>
+
+      <div class="col-md-2">
+        <%= submit "Retry selected now", class: "btn btn-success btn-sm", name: "action", value: "requeue" %>
       </div>
 
       <div class="col-md-8 text-right">


### PR DESCRIPTION
Sorry this is so delayed!
Fixes #11 

I'm opening this early to get some feedback. It doesn't work right now because the `requeue_job_now` script doesn't catch when the job is just an empty string `""` here: https://github.com/edgurgel/verk/blob/e39293e0e65abca14a69ae05990debc74b8ece65/priv/requeue_job_now.lua#L3 and the first value in the form data is always `""`.

To resolve that I can either patch the job in Verk, or delete the first element in the form data.

Also wanted to get feedback on changing the `delete` method to `post` and modifying the controller logic.

Let me know what your thoughts are.