### PR TITLE
Fix SharedView when enqueued_at is a float

### DIFF
--- a/test/views/shared_view_test.exs
+++ b/test/views/shared_view_test.exs
@@ -1,0 +1,18 @@
+defmodule VerkWeb.SharedViewTest do
+  use VerkWeb.ConnCase, async: true
+  alias VerkWeb.SharedView
+
+  describe "enqueued_at/1" do
+    test "with nil" do
+      assert SharedView.enqueued_at(nil) == "N/A"
+    end
+
+    test "with enqueued_at as integer" do
+      assert SharedView.enqueued_at(0) =~ ~r/.* years ago/
+    end
+
+    test "with enqueued_at as float" do
+      assert SharedView.enqueued_at(1.5) =~ ~r/.* years ago/
+    end
+  end
+end

--- a/web/views/shared_view.ex
+++ b/web/views/shared_view.ex
@@ -3,6 +3,6 @@ defmodule VerkWeb.SharedView do
 
   def enqueued_at(nil), do: "N/A"
   def enqueued_at(timestamp) do
-    timestamp |> Timex.from_unix |> Timex.format!("{relative}", :relative)
+    timestamp |> round |> Timex.from_unix |> Timex.format!("{relative}", :relative)
   end
 end


### PR DESCRIPTION
Some clients may add enqueued_at as seconds but as a float

`Timex.from_unix` expects integer