### PR TITLE
Show error backtrace in job modal

### DIFF
--- a/web/templates/shared/job_modal.html.eex
+++ b/web/templates/shared/job_modal.html.eex
@@ -42,10 +42,18 @@
             <th>Retry Count</th>
             <td><%= @job.retry_count %></td>
           </tr>
-          <tr>
-            <th>Error Message</th>
-            <td><pre><%= @job.error_message %></pre></td>
-          </tr>
+          <%= if @job.error_message do %>
+            <tr>
+              <th>Error Message</th>
+              <td><pre><%= @job.error_message %></pre></td>
+            </tr>
+          <% end %>
+          <%= if @job.error_backtrace do %>
+            <tr>
+              <th>Error Backtrace</th>
+              <td><pre><%= error_backtrace(@job.error_backtrace) %></pre></td>
+            </tr>
+          <% end %>
           </tbody>
         </table>
       </div>

--- a/web/views/shared_view.ex
+++ b/web/views/shared_view.ex
@@ -5,4 +5,9 @@ defmodule VerkWeb.SharedView do
   def enqueued_at(timestamp) do
     timestamp |> round |> Timex.from_unix |> Timex.format!("{relative}", :relative)
   end
+
+  def error_backtrace(nil), do: "N/A"
+  def error_backtrace(string) do
+    Regex.replace(~r( {2,}), string, "")
+  end
 end


### PR DESCRIPTION
To make debugging failed jobs easier, display the error backtrace in the job modal.

Here's how it looks like:

<img width="1279" alt="screen shot 2018-01-22 at 20 39 27" src="https://user-images.githubusercontent.com/7852553/35241339-6cb45076-ffb6-11e7-9448-ac0aa3d5360b.png">

Possibly it's not the prettiest thing ever, but useful. If you have some suggestions on how to improve this view, I'll gladly put them into action. I did not want to do a big makeover without a general approval of this feature.