### PR TITLE
Add "Enqueue selected now" button to scheduled jobs.

### DIFF
--- a/test/controllers/scheduled_controller_test.exs
+++ b/test/controllers/scheduled_controller_test.exs
@@ -9,12 +9,19 @@ defmodule VerkWeb.ScheduledControllerTest do
     :ok
   end
 
-  test "DELETE / jobs delete specific jobs", %{conn: conn} do
+  test "POST / jobs delete specific jobs", %{conn: conn} do
     fake_job_json = "{\"jid\": \"123\"}"
     expect(SortedSet, :delete_job!, ["schedule", fake_job_json, Redis], :ok)
-    conn = delete conn, "/scheduled", jobs_to_remove: [fake_job_json]
+    conn = post conn, "/scheduled", [jobs_to_modify: [fake_job_json], action: "delete"]
     assert validate SortedSet
     assert redirected_to(conn) == "/scheduled"
+  end
+
+  test "POST / action scheduled jobs retries specific jobs", %{conn: conn} do
+    fake_job_json = "{\"jid\": \"123\"}"
+    expect(SortedSet, :requeue_job!, ["schedule", fake_job_json, Redis], :ok)
+    post conn, "/scheduled", [jobs_to_modify: [fake_job_json], action: "requeue"]
+    assert validate SortedSet
   end
 
   test "DELETE / passing no jobs deletes all jobs", %{conn: conn} do

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,6 +27,7 @@ defmodule VerkWeb.Router do
     post "/retries", RetriesController, :modify
     delete "/retries", RetriesController, :destroy
     get "/scheduled", ScheduledController, :index
+    post "/scheduled", ScheduledController, :modify
     delete "/scheduled", ScheduledController, :destroy
     get "/dead", DeadController, :index
     delete "/dead", DeadController, :destroy

--- a/web/templates/scheduled/index.html.eex
+++ b/web/templates/scheduled/index.html.eex
@@ -4,8 +4,8 @@
   <p>No scheduled jobs.</p>
 <% else %>
   <div>
-    <%= form_for @conn, scheduled_path(@conn, :destroy), [as: :delete_job, method: "DELETE"], fn _ -> %>
-      <input name="jobs_to_remove[]" type="hidden" value="" />
+    <%= form_for @conn, scheduled_path(@conn, :modify), [as: :modify, method: "POST"], fn _ -> %>
+      <input name="jobs_to_modify[]" type="hidden" value="" />
       <table class="table">
         <thead>
           <tr>
@@ -21,7 +21,7 @@
         <tbody>
         <%= for job <- scheduled_jobs(@scheduled_jobs) do %>
           <tr>
-            <td><input name="jobs_to_remove[]" type="checkbox" value="<%= job.job.original_json %>" id="job_<%= job.jid %>" /></td>
+            <td><input name="jobs_to_modify[]" type="checkbox" value="<%= job.job.original_json %>" id="job_<%= job.jid %>" /></td>
             <td><%= perform_at(job.perform_at) %></td>
             <td><%= job.queue %></td>
             <td><%= job.jid %></td>
@@ -41,7 +41,11 @@
 
       <div class="row">
         <div class="col-md-4">
-          <%= submit "Delete selected", class: "btn btn-danger btn-sm" %>
+          <%= submit "Delete selected", class: "btn btn-danger btn-sm", name: "action", value: "delete" %>
+        </div>
+
+        <div class="col-md-2">
+          <%= submit "Queue selected now", class: "btn btn-success btn-sm", name: "action", value: "requeue" %>
         </div>
 
         <div class="col-md-8 text-right">

--- a/web/templates/scheduled/index.html.eex
+++ b/web/templates/scheduled/index.html.eex
@@ -45,7 +45,7 @@
         </div>
 
         <div class="col-md-2">
-          <%= submit "Queue selected now", class: "btn btn-success btn-sm", name: "action", value: "requeue" %>
+          <%= submit "Enqueue selected now", class: "btn btn-success btn-sm", name: "action", value: "requeue" %>
         </div>
 
         <div class="col-md-8 text-right">


### PR DESCRIPTION
This PR adds a `Enqueue selected now` button to the scheduled jobs page. The code models the retries_controller and the template logic associated.

- Add `post` route for schedule
- Move logic from `delete` to `modify`
- Add Test Coverage

![screen shot 2018-07-09 at 9 07 03 pm](https://user-images.githubusercontent.com/503033/42488778-19781138-83bc-11e8-80e0-5193d56f9f25.png)
