### PR TITLE
README has inconsistent version for instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First, add Verk Web to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:verk_web, "~> 1.0"},
+  [{:verk_web, "~> 1.5.1"},
    {:verk,     "~> 1.0"}]
 end
 ```


### PR DESCRIPTION
When using verk_web 1.0, `use VerkWeb.MountRoute, path: "/verk"` does
not work because `VerkWeb.MountRoute` was introduced in a later version.

Thanks @adrian-joinpapa